### PR TITLE
add ecr repo upload workflow based on deployment name

### DIFF
--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -45,7 +45,7 @@ jobs:
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           DEPLOYMENT_NAME: ${{ steps.vars.outputs.deployment }}
         run: |
-          docker build -t ${{ env.DEPLOYMENT_NAME }} -f ./Dockerfile
+          docker build -f ./Dockerfile -t ${{ env.DEPLOYMENT_NAME }} .
           # push to remote repository with branch deployment as tag
           docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.DEPLOYMENT_NAME }}
           # push to remote repository with git sha as tag

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -17,7 +17,7 @@ jobs:
           aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ github.ref }}/${{ github.sha }}
+          role-session-name: ${GITHUB_REF#refs/*/}/${{ github.sha }}
           aws-region: eu-west-1
 
       - name: Login to Amazon ECR
@@ -28,7 +28,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
-          DEPLOYMENT_NAME: $(echo ${{ github.ref }} | sed 's/.*deploy\///')
+          DEPLOYMENT_NAME: $(echo ${GITHUB_REF#refs/*/} | sed 's/.*deploy\///')
         run: |
           docker build -t $DEPLOYMENT_NAME -f ./Dockerfile
           # push to remote repository with branch deployment as tag

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Output branch name
+      - name: Output variable names
         id: vars
         run: |
           export BRANCH=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -13,7 +13,9 @@ jobs:
 
       - name: Output branch name
         id: vars
-        run: echo ::set-output name=branch::${GITHUB_REF#refs/*/}
+        run: |
+          echo ::set-output name=branch::${GITHUB_REF#refs/*/}
+          echo ::set-output name=short_sha::$(git rev-parse --short HEAD)
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -21,7 +23,7 @@ jobs:
           aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ steps.vars.outputs.branch }}/${{ github.sha }}
+          role-session-name: $(echo ${{ steps.vars.outputs.branch }}-${{ steps.vars.outputs.branch }} | sed 's/.*\///')
           aws-region: eu-west-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -14,6 +14,7 @@ jobs:
   upload-to-ecr:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
 
       - name: Output branch name
         id: vars
@@ -39,15 +40,47 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build and push to ECR
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Docker Buildx build
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+        run: |
+          docker buildx build \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache" \
+            --output "type=image,push=false" \
+            --tag ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }} \
+            --file ./Dockerfile ./
+
+      - name: Docker Buildx push
+        id: tag-images-and-push
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           DEPLOYMENT_NAME: ${{ steps.vars.outputs.deployment }}
         run: |
-          docker build -f ./Dockerfile -t ${{ env.DEPLOYMENT_NAME }} .
-          # push to remote repository with branch deployment as tag
-          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.DEPLOYMENT_NAME }}
           # push to remote repository with git sha as tag
-          docker tag ${{ env.DEPLOYMENT_NAME }} ${{ github.sha }}
-          docker push ${{ github.sha }}
+          docker buildx build \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --output "type=image,push=true" \
+            --tag ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }} \
+            --file ./Dockerfile ./
+          # push to remote repository with branch deployment as tag
+          docker buildx build \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --output "type=image,push=true" \
+            --tag ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.DEPLOYMENT_NAME }} \
+            --file ./Dockerfile ./

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -14,18 +14,18 @@ jobs:
       - name: Output branch name
         id: vars
         run: |
-          echo ::set-output name=branch::${GITHUB_REF#refs/*/}
-          echo ::set-output name=short_sha::$(git rev-parse --short HEAD)
+          echo ::set-output name=branch::${GITHUB_REF#refs/*/} | sed 's/.*\///'
+          echo ::set-output name=short_sha::${GITHUB_SHA: -7:1}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         env:
-          SESSION_NAME: $(echo ${{ steps.vars.outputs.branch }} | sed 's/.*\///')-${{ steps.vars.outputs.short_sha }}
+          SESSION_NAME: ${{ steps.vars.outputs.branch }}-${{ steps.vars.outputs.short_sha }}
         with:
           aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
-          role-session-name: $SESSION_NAME
+          role-session-name: ${{ env.SESSION_NAME }}
           aws-region: eu-west-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -1,0 +1,38 @@
+name: Upload Image To ECR
+
+on:
+  push:
+    branches:
+      - '*deploy/*'
+
+jobs:
+
+  upload-to-ecr:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.ref }}/${{ github.sha }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build and push to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          DEPLOYMENT_NAME: $(echo ${{ }} | sed 's/.*deploy\///')
+        run: |
+          docker build -t $DEPLOYMENT_NAME -f ./Dockerfile
+          # push to remote repository with branch deployment as tag
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$DEPLOYMENT_NAME
+          # push to remote repository with git sha as tag
+          docker tag $DEPLOYMENT_NAME ${{ github.sha }}
+          docker push ${{ github.sha }}

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*deploy/*'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   upload-to-ecr:
@@ -14,8 +18,11 @@ jobs:
       - name: Output branch name
         id: vars
         run: |
-          echo ::set-output name=branch::${GITHUB_REF#refs/*/} | sed 's/.*\///'
-          echo ::set-output name=short_sha::${GITHUB_SHA: -7:1}
+          export BRANCH=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
+          echo ::set-output name=branch::$BRANCH
+          echo ::set-output name=short_sha::${GITHUB_SHA: -8}
+          export DEPLOYMENT=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*deploy\///')
+          echo ::set-output name=deployment::$DEPLOYMENT
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -36,11 +43,11 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
-          DEPLOYMENT_NAME: $(echo ${{ steps.vars.outputs.branch }} | sed 's/.*deploy\///')
+          DEPLOYMENT_NAME: ${{ steps.vars.outputs.deployment }}
         run: |
-          docker build -t $DEPLOYMENT_NAME -f ./Dockerfile
+          docker build -t ${{ env.DEPLOYMENT_NAME }} -f ./Dockerfile
           # push to remote repository with branch deployment as tag
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$DEPLOYMENT_NAME
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.DEPLOYMENT_NAME }}
           # push to remote repository with git sha as tag
-          docker tag $DEPLOYMENT_NAME ${{ github.sha }}
+          docker tag ${{ env.DEPLOYMENT_NAME }} ${{ github.sha }}
           docker push ${{ github.sha }}

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -11,13 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Output branch name
+        id: vars
+        run: echo ::set-output name=branch::${GITHUB_REF#refs/*/}
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${GITHUB_REF#refs/*/}/${{ github.sha }}
+          role-session-name: ${{ steps.vars.outputs.branch }}/${{ github.sha }}
           aws-region: eu-west-1
 
       - name: Login to Amazon ECR
@@ -28,7 +32,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
-          DEPLOYMENT_NAME: $(echo ${GITHUB_REF#refs/*/} | sed 's/.*deploy\///')
+          DEPLOYMENT_NAME: $(echo ${{ steps.vars.outputs.branch }} | sed 's/.*deploy\///')
         run: |
           docker build -t $DEPLOYMENT_NAME -f ./Dockerfile
           # push to remote repository with branch deployment as tag

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.ref }}/${{ github.sha }}
           aws-region: eu-west-1
 

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -19,11 +19,13 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
+        env:
+          SESSION_NAME: $(echo ${{ steps.vars.outputs.branch }} | sed 's/.*\///')-${{ steps.vars.outputs.short_sha }}
         with:
           aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
-          role-session-name: $(echo ${{ steps.vars.outputs.branch }}-${{ steps.vars.outputs.branch }} | sed 's/.*\///')
+          role-session-name: $SESSION_NAME
           aws-region: eu-west-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/upload-ecr.yml
+++ b/.github/workflows/upload-ecr.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
-          DEPLOYMENT_NAME: $(echo ${{ }} | sed 's/.*deploy\///')
+          DEPLOYMENT_NAME: $(echo ${{ github.ref }} | sed 's/.*deploy\///')
         run: |
           docker build -t $DEPLOYMENT_NAME -f ./Dockerfile
           # push to remote repository with branch deployment as tag


### PR DESCRIPTION
This Github Action workflow infers deployment name/title from branch name and tags + uploads the image with this name in the service's remote repository. The images referenced will be updated as new commits are pushed to these branches.