### PR TITLE
Only use test configurations when not deploying to QA or Live.

### DIFF
--- a/production/bin/configurator.sh
+++ b/production/bin/configurator.sh
@@ -7,6 +7,8 @@ if [[ -z ${GITHUB_TOKEN+x} || -z ${DEPLOY_ENV+x} || -z ${APP+x} ]]; then
 	exit 1
 fi
 
-cp config/cookies.json.example config/cookies.json
-cp .env_file.test .env_file
-
+if [[ "$DEPLOY_ENV" != "qa" && "$DEPLOY_ENV" != "live" ]]; then
+	# Only use the test configurations if we're not deploying to QA or Live.
+	cp config/cookies.json.example config/cookies.json
+	cp .env_file.test .env_file
+fi


### PR DESCRIPTION
This change only copies the test env_file and cookies file into place if we're *not* deploying to QA or Live. 