### PR TITLE
Correct startup for QA and Live deployments

### DIFF
--- a/production/bin/configurator.sh
+++ b/production/bin/configurator.sh
@@ -7,6 +7,8 @@ if [[ -z ${GITHUB_TOKEN+x} || -z ${DEPLOY_ENV+x} || -z ${APP+x} ]]; then
 	exit 1
 fi
 
-cp config/cookies.json.example config/cookies.json
-cp .env_file.test .env_file
-
+if [[ "$DEPLOY_ENV" != "qa" && "$DEPLOY_ENV" != "live" ]]; then
+	# Only use the test configurations if we're not deploying to QA or Live.
+	cp config/cookies.json.example config/cookies.json
+	cp .env_file.test .env_file
+fi

--- a/production/bin/configurator.sh
+++ b/production/bin/configurator.sh
@@ -11,4 +11,7 @@ if [[ "$DEPLOY_ENV" != "qa" && "$DEPLOY_ENV" != "live" ]]; then
 	# Only use the test configurations if we're not deploying to QA or Live.
 	cp config/cookies.json.example config/cookies.json
 	cp .env_file.test .env_file
+else
+	# The dumb-init process requires an .env_file. Leave it empty.
+	touch .env_file
 fi


### PR DESCRIPTION
The dumb-init process for fetch expects a .env_file to be present. Use an empty one for QA and Live.