### PR TITLE
The dumb-init process requires an .env_file. Use an empty one for QA and Live.

### DIFF
--- a/production/bin/configurator.sh
+++ b/production/bin/configurator.sh
@@ -11,4 +11,7 @@ if [[ "$DEPLOY_ENV" != "qa" && "$DEPLOY_ENV" != "live" ]]; then
 	# Only use the test configurations if we're not deploying to QA or Live.
 	cp config/cookies.json.example config/cookies.json
 	cp .env_file.test .env_file
+else
+	# The dumb-init process expects an .env_file. Use an empty one for QA and Live.
+	touch .env_file
 fi


### PR DESCRIPTION
This fixes a bug where the dumb-init process expects an .env_file and dies if not present. Use an empty one for QA and Live.