### PR TITLE
Ticket CHECK-2686: Adding Bengali and Malayalam Newschecker sources

### DIFF
--- a/lib/claim_review_parsers/news_checker.rb
+++ b/lib/claim_review_parsers/news_checker.rb
@@ -13,6 +13,8 @@ class NewsChecker < ClaimReviewParser
       "https://newschecker.in/bh",
       "https://newschecker.in/ka",
       "https://newschecker.in/kn",
+      "https://newschecker.in/bn",
+      "https://newschecker.in/ml",
     ]
   end
 


### PR DESCRIPTION
Newschecker parser should also get articles from these two sources:

* https://newschecker.in/bn - Bengali
* https://newschecker.in/ml - Malayalam