### PR TITLE
CV2-2772 add safe url acessing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - kibana
       - redis
     build: .
+    platform: linux/x86_64
     ports:
       - "9292:9292"
     env_file:

--- a/lib/alegre_client.rb
+++ b/lib/alegre_client.rb
@@ -1,6 +1,6 @@
 class AlegreClient
   def self.host
-    Settings.get("alegre_host_url")
+    Settings.get_safe_url("alegre_host_url")
   end
 
   def self.get_enrichment_for_url(url)

--- a/lib/pender_client.rb
+++ b/lib/pender_client.rb
@@ -1,6 +1,6 @@
 class PenderClient
   def self.host
-    Settings.get("pender_host_url")
+    Settings.get_safe_url("pender_host_url")
   end
 
   def self.get_enrichment_for_url(url)

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -1,9 +1,9 @@
 class Settings
-  
+
   def self.get_claim_review_es_index_name
     Settings.get('es_index_name')
   end
-  
+
   def self.get_claim_review_social_data_es_index_name
     Settings.get('es_index_name_cr_social_data')
   end
@@ -11,7 +11,7 @@ class Settings
   def self.get_stored_subscription_es_index_name
     Settings.get('es_index_name_stored_subscription')
   end
-  
+
   def self.airbrake_specified?
     Settings.blank?('airbrake_api_host')
   end
@@ -22,6 +22,10 @@ class Settings
 
   def self.get(var_name)
     ENV[var_name] || self.defaults[var_name]
+  end
+
+  def self.get_safe_url(var_name)
+    (safe_url = self.get(var_name)).end_with?('/') ? safe_url : safe_url+'/'
   end
 
   def self.blank?(var_name)
@@ -104,7 +108,7 @@ class Settings
   def self.task_interevent_time
     self.in_qa_mode? ? 60 * 60 * 24 : 60 * 60
   end
-  
+
   def self.default_task_count(task)
     {
       snowball_claim_reviews_from_publishers: 1,

--- a/spec/lib/alegre_client_test.rb
+++ b/spec/lib/alegre_client_test.rb
@@ -17,7 +17,7 @@ describe AlegreClient do
       response = {"title"=>"AFP Covid-19 verification hub"}
       expect(AlegreClient.get_enrichment_for_url("http://example.com/link")).to(eq(response))
     end
-    
+
     it 'degrades gracefully when Alegre errors out' do
       RestClient::ServiceUnavailable.any_instance.stub(:http_code).and_return(500)
       RestClient::Request.stub(:execute).and_raise(RestClient::ServiceUnavailable.new)

--- a/spec/lib/alegre_client_test.rb
+++ b/spec/lib/alegre_client_test.rb
@@ -1,12 +1,11 @@
 describe AlegreClient do
   before do
-    stub_request(:post, "alegre:3100/article/").
+    stub_request(:post, "#{Settings.get_safe_url("alegre_host_url")}article/").
       with(
         body: {"url"=>"http://example.com/link"},
         headers: {
           'Accept'=>'*/*',
           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Host'=>"alegre:3100",
           "User-Agent": /.*/
         }).
       to_return(status: 200, body: '{"title":"AFP Covid-19 verification hub"}', headers: {})

--- a/spec/lib/alegre_client_test.rb
+++ b/spec/lib/alegre_client_test.rb
@@ -1,12 +1,12 @@
 describe AlegreClient do
   before do
-    stub_request(:post, "http://alegre.local/article/").
+    stub_request(:post, "alegre:3100/article/").
       with(
         body: {"url"=>"http://example.com/link"},
         headers: {
-      	  'Accept'=>'*/*',
-      	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      	  'Host'=>'alegre.local',
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>"alegre:3100",
           "User-Agent": /.*/
         }).
       to_return(status: 200, body: '{"title":"AFP Covid-19 verification hub"}', headers: {})

--- a/spec/lib/pender_client_test.rb
+++ b/spec/lib/pender_client_test.rb
@@ -13,21 +13,19 @@
 #
 describe PenderClient do
   before do
-    stub_request(:get, "http://pender.local/api/medias.json?url=https://twitter.com/meedan/status/773947372527288320/").
+    stub_request(:get, "#{Settings.get_safe_url("pender_host_url")}api/medias.json?url=https://twitter.com/meedan/status/773947372527288320/").
       with(
         headers: {
-      	  'Accept'=>'*/*',
-      	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      	  'Host'=>'pender.local',
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           "User-Agent": /.*/
         }).
       to_return(status: 200, body: File.read("spec/fixtures/pender_response.json"), headers: {})
-    stub_request(:get, "http://pender.local/api/medias.json?url=http://example.com/link").
+    stub_request(:get, "#{Settings.get_safe_url("pender_host_url")}api/medias.json?url=http://example.com/link").
       with(
         headers: {
-      	  'Accept'=>'*/*',
-      	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      	  'Host'=>'pender.local',
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           "User-Agent": /.*/
         }).
       to_return(status: 200, body: File.read("spec/fixtures/pender_response.json"), headers: {})
@@ -37,11 +35,11 @@ describe PenderClient do
     it 'expects no pender response' do
       expect(PenderClient.get_enrichment_for_url("http://example.com/link")).to(eq({}))
     end
-    
+
     it 'expects a pender response' do
       expect(PenderClient.get_enrichment_for_url("https://twitter.com/meedan/status/773947372527288320/")).to(eq(JSON.parse(File.read("spec/fixtures/pender_response.json"))))
     end
-    
+
     it 'degrades gracefully when Alegre errors out' do
       RestClient::ServiceUnavailable.any_instance.stub(:http_code).and_return(500)
       RestClient::Request.stub(:execute).and_raise(RestClient::ServiceUnavailable.new)


### PR DESCRIPTION
- We created `get_safe_url` in `settings.rb` so it would check if there is a trailing slash at the end of the environment variable, and add one when there isn't.
- We updated the `stub_request` in the `alegre_client_test` and `pender_client_test`: we were getting an error because of the Host. Since it's not necessary we removed it. Also updated to use `Settings.get_safe_url` instead of hardcoding the url.
- I needed to update the `docker-compose` file, added `platform`, so it would run on the mac m1.