### PR TITLE
use OIDC deploy role for workflows

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -7,6 +7,10 @@ on:
       - 'master'
       - '*deploy/*'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -26,11 +26,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-        role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ vars.AWS_OIDC_ROLE_TO_ASSUME }}
         aws-region: eu-west-1
 
     - name: Login to Amazon ECR

--- a/.github/workflows/ci-test-branches.yml
+++ b/.github/workflows/ci-test-branches.yml
@@ -14,11 +14,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-        role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ vars.AWS_OIDC_ROLE_TO_ASSUME }}
         aws-region: eu-west-1
 
     - name: Login to Amazon ECR

--- a/.github/workflows/ci-test-branches.yml
+++ b/.github/workflows/ci-test-branches.yml
@@ -3,6 +3,10 @@ name: Build and Test Commits
 on:
   push
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -22,11 +22,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-        role-to-assume: ${{ secrets.TEST_AWS_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ vars.AWS_OIDC_ROLE_TO_ASSUME }}
         aws-region: eu-west-1
 
     - name: Login to Amazon ECR

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -3,6 +3,10 @@ name: Build and Run Integration Test
 on:
   pull_request
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This changes all github actions workflows to use implicit OIDC provider credentials instead of pulling deploy role credentials to authenticate with AWS IAM. Role ARN is stored as a github actions variable.