### PR TITLE
CV2-3110: Sunset Fetch Fatabyyano parser

### DIFF
--- a/lib/claim_review_parsers/fatabyyano.rb
+++ b/lib/claim_review_parsers/fatabyyano.rb
@@ -3,6 +3,10 @@
 # Parser for https://fatabyyano.net/fake_news/
 class Fatabyyano < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+  
   def hostname
     'https://fatabyyano.net'
   end


### PR DESCRIPTION
We don't need to support this parser anymore.
Added a self.deprecated method return value of true which it makes it no longer an enabled subclass.

The way I tested this was trying to run the parser. Got a NoMethodError, which I'm thinking is what is expected.