### PR TITLE
Cv2 2849 titles not captured for some thip articles

### DIFF
--- a/lib/claim_review_parsers/thip.rb
+++ b/lib/claim_review_parsers/thip.rb
@@ -33,16 +33,30 @@ class Thip < ClaimReviewParser
   end
 
   def parse_raw_claim_review(raw_claim_review)
-    parsed_page = Nokogiri.parse("<html>"+raw_claim_review["raw_response"]["content"]["rendered"]+"</html>")
+    claim_review = extract_ld_json_script_block(raw_claim_review["page"], 0)
+    binding.pry
+    # parsed_page = Nokogiri.parse("<html>"+raw_claim_review["raw_response"]["content"]["rendered"]+"</html>")
+    # {
+    #   id: raw_claim_review['url'],
+    #   author: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["display_name"],
+    #   author_link: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["author_link"],
+    #   created_at: (Time.parse(raw_claim_review["raw_response"]["date"]) rescue nil),
+    #   claim_review_headline: raw_claim_review["raw_response"]["yoast_head_json"]["title"].split(" - ")[0..-2].join(" - "),
+    #   claim_review_body: (parsed_page.search("div.wp-block-media-text").first.text.strip rescue parsed_page.text),
+    #   claim_review_image_url: raw_claim_review["raw_response"]["featured_img"],
+    #   claim_review_result: parsed_page.search("p.has-regular-font-size strong").text.gsub(".", ""),
+    #   claim_review_url: raw_claim_review['url'],
+    #   raw_claim_review: raw_claim_review["raw_response"]
+    # }
     {
       id: raw_claim_review['url'],
-      author: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["display_name"],
-      author_link: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["author_link"],
-      created_at: (Time.parse(raw_claim_review["raw_response"]["date"]) rescue nil),
-      claim_review_headline: raw_claim_review["raw_response"]["yoast_head_json"]["title"].split(" - ")[0..-2].join(" - "),
-      claim_review_body: (parsed_page.search("div.wp-block-media-text").first.text.strip rescue parsed_page.text),
-      claim_review_image_url: raw_claim_review["raw_response"]["featured_img"],
-      claim_review_result: parsed_page.search("p.has-regular-font-size strong").text.gsub(".", ""),
+      author: claim_review["@graph"][8]["name"],
+      # author_link: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["author_link"],
+      created_at: (Time.parse(claim_review["@graph"][0]["dateCreated"]) rescue nil),
+      claim_review_headline: claim_review["@graph"][0]["name"].split(" ")[0..-2].join("-"),
+      claim_review_body: claim_review["@graph"][0]["description"],
+      # claim_review_image_url: raw_claim_review["raw_response"]["featured_img"],
+      claim_review_result: claim_review["@graph"][0]["reviewRating"]["alternateName"],
       claim_review_url: raw_claim_review['url'],
       raw_claim_review: raw_claim_review["raw_response"]
     }

--- a/lib/claim_review_parsers/thip.rb
+++ b/lib/claim_review_parsers/thip.rb
@@ -4,7 +4,7 @@
 class Thip < ClaimReviewParser
   attr_accessor :raw_response
   include PaginatedReviewClaims
-  def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
+  def initialize(cursor_back_to_date = nil, overwrite_existing_claims = false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'json'
     @raw_response = {}
@@ -32,33 +32,28 @@ class Thip < ClaimReviewParser
     response
   end
 
+  def get_headline(raw_claim_review)
+    if raw_claim_review["raw_response"]["yoast_head_json"]["title"].empty?
+        raw_claim_review["raw_response"]["title"]["rendered"].include?("THIP Media") ? raw_claim_review["raw_response"]["title"]["rendered"].split(/ &ndash; | - /)[0..-2].join(" ") : raw_claim_review["raw_response"]["yoast_head_json"]["title"]
+    else
+      raw_claim_review["raw_response"]["yoast_head_json"]["title"].include?("THIP Media") ? raw_claim_review["raw_response"]["yoast_head_json"]["title"].split(/ &ndash; | - /)[0..-2].join(" ") : raw_claim_review["raw_response"]["yoast_head_json"]["title"]
+    end
+  end
+
   def parse_raw_claim_review(raw_claim_review)
-    claim_review = extract_ld_json_script_block(raw_claim_review["page"], 0)
-    binding.pry
-    # parsed_page = Nokogiri.parse("<html>"+raw_claim_review["raw_response"]["content"]["rendered"]+"</html>")
-    # {
-    #   id: raw_claim_review['url'],
-    #   author: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["display_name"],
-    #   author_link: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["author_link"],
-    #   created_at: (Time.parse(raw_claim_review["raw_response"]["date"]) rescue nil),
-    #   claim_review_headline: raw_claim_review["raw_response"]["yoast_head_json"]["title"].split(" - ")[0..-2].join(" - "),
-    #   claim_review_body: (parsed_page.search("div.wp-block-media-text").first.text.strip rescue parsed_page.text),
-    #   claim_review_image_url: raw_claim_review["raw_response"]["featured_img"],
-    #   claim_review_result: parsed_page.search("p.has-regular-font-size strong").text.gsub(".", ""),
-    #   claim_review_url: raw_claim_review['url'],
-    #   raw_claim_review: raw_claim_review["raw_response"]
-    # }
+    parsed_page = Nokogiri.parse("<html>"+raw_claim_review["raw_response"]["content"]["rendered"]+"</html>")
+
     {
       id: raw_claim_review['url'],
-      author: claim_review["@graph"][8]["name"],
-      # author_link: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["author_link"],
-      created_at: (Time.parse(claim_review["@graph"][0]["dateCreated"]) rescue nil),
-      claim_review_headline: claim_review["@graph"][0]["name"].split(" ")[0..-2].join("-"),
-      claim_review_body: claim_review["@graph"][0]["description"],
-      # claim_review_image_url: raw_claim_review["raw_response"]["featured_img"],
-      claim_review_result: claim_review["@graph"][0]["reviewRating"]["alternateName"],
+      author: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["display_name"],
+      author_link: raw_claim_review["raw_response"]["author_meta"] && raw_claim_review["raw_response"]["author_meta"]["author_link"],
+      created_at: (Time.parse(raw_claim_review["raw_response"]["date"]) rescue nil),
+      claim_review_headline: get_headline(raw_claim_review),
+      claim_review_body: (parsed_page.search("div.wp-block-media-text").first.text.strip rescue parsed_page.text),
+      claim_review_image_url: raw_claim_review["raw_response"]["featured_img"],
+      claim_review_result: parsed_page.search("p.has-regular-font-size strong").text.gsub(".", ""),
       claim_review_url: raw_claim_review['url'],
-      raw_claim_review: raw_claim_review["raw_response"]
+      raw_claim_review: raw_claim_review["raw_response"],
     }
   end
 end


### PR DESCRIPTION
Some of the titles for Thip articles were missing. This was probably because we were removing the ' - THIP Media' from the headlines by looking for a hyphen, but in some cases it was an en dash. When that was the case we got an empty string.

I fixed that and added a fallback, re-fetched the claims and got 0 missing headlines 🎉 
