### PR TITLE
update github action deploy workflow action versions

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       image: ${{ steps.build-image.outputs.image }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v2
@@ -40,10 +40,10 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: /tmp/.buildx-cache


### PR DESCRIPTION
old versions included deprecated steps that threw out workflow warnings, this updates several of them to use the recommended most recent versions instead.