### PR TITLE
remove twitter from allowed_hostnames in pender client

### DIFF
--- a/lib/pender_client.rb
+++ b/lib/pender_client.rb
@@ -40,11 +40,9 @@ class PenderClient
 
   def self.allowed_hostnames
     %w{
-      twitter.com
       perma.cc
       www.facebook.com
       www.youtube.com
-      t.co
       web.archive.org
       www.google.com
       www.tumblr.com

--- a/spec/fixtures/pender_response.json
+++ b/spec/fixtures/pender_response.json
@@ -1,1 +1,353 @@
-{"data": {"raw": {}, "schema": {}},"published_at":"Thu Sep 08 18:13:27 +0000 2016","username":"@meedan","title":"Thrilled to announce our participation in #Electionland w/@propublica @firstdraftnews and introduce @Check https://t.co/sVZBEZk3NY","description":"Thrilled to announce our participation in #Electionland w/@propublica @firstdraftnews and  introduce @Check https://t.co/sVZBEZk3NY","picture":null,"author_url":"https://twitter.com/meedan","author_picture":"https://pbs.twimg.com/profile_images/875455750557937664/HAjXGzZ2.jpg","author_name":"meedan","screenshot":"","external_id":"773947372527288320","html":"<blockquote class=\"twitter-tweet\"><a href=\"https://twitter.com/meedan/status/773947372527288320/\"></a></blockquote><script async src=\"//platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>","raw":{"metatags":[{"charset":"utf-8"},{"name":"viewport","content":"width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0,viewport-fit=cover"},{"property":"fb:app_id","content":"2231777543"},{"property":"og:site_name","content":"Twitter"},{"name":"google-site-verification","content":"V0yIS0Ec_o3Ii9KThrCoMCkwTYMMJ_JYx_RSaGhFYvw"},{"name":"mobile-web-app-capable","content":"yes"},{"name":"apple-mobile-web-app-title","content":"Twitter"},{"name":"apple-mobile-web-app-status-bar-style","content":"white"},{"name":"theme-color","content":"#ffffff"},{"http-equiv":"origin-trial","content":"Ap6SMBNB0lQoXpXl4I9vyTJqJ7Y0X9tPd6Q6rN697iHdubQQxBcWHy21N3N7uEz7Ba5UKMbN+eLvDczBSbi27AsAAABfeyJvcmlnaW4iOiJodHRwczovL3R3aXR0ZXIuY29tOjQ0MyIsImZlYXR1cmUiOiJCYWRnaW5nIiwiZXhwaXJ5IjoxNTY0NTgyNzY2LCJpc1N1YmRvbWFpbiI6dHJ1ZX0="},{"http-equiv":"origin-trial","content":"Apir4chqTX+4eFxKD+ErQlKRB/VtZ/dvnLfd9Y9Nenl5r1xJcf81alryTHYQiuUlz9Q49MqGXqyaiSmqWzHUqQwAAABneyJvcmlnaW4iOiJodHRwczovL3R3aXR0ZXIuY29tOjQ0MyIsImZlYXR1cmUiOiJDb250YWN0c01hbmFnZXIiLCJleHBpcnkiOjE1NzUwMzUyODMsImlzU3ViZG9tYWluIjp0cnVlfQ=="},{"http-equiv":"origin-trial","content":"AleGS26SZL7UA8Fe1DbvXzoay74bPTvrfKKGimIu1RI8vA+RtXOSVlizUkz2zU/fQoFoOTgCiCciP6pM5teaeQgAAABjeyJvcmlnaW4iOiJodHRwczovL3R3aXR0ZXIuY29tOjQ0MyIsImZlYXR1cmUiOiJTbXNSZWNlaXZlciIsImV4cGlyeSI6MTU3OTAyMDkyMSwiaXNTdWJkb21haW4iOnRydWV9"}],"api":{"created_at":"Thu Sep 08 18:13:27 +0000 2016","id":773947372527288320,"id_str":"773947372527288320","full_text":"Thrilled to announce our participation in #Electionland w/@propublica @firstdraftnews and  introduce @Check https://t.co/sVZBEZk3NY","truncated":false,"display_text_range":[0,131],"entities":{"hashtags":[{"text":"Electionland","indices":[42,55]}],"symbols":[],"user_mentions":[{"screen_name":"propublica","name":"ProPublica","id":14606079,"id_str":"14606079","indices":[58,69]},{"screen_name":"firstdraftnews","name":"First Draft","id":3314775459,"id_str":"3314775459","indices":[70,85]},{"screen_name":"check","name":"Check","id":12765,"id_str":"12765","indices":[101,107]}],"urls":[{"url":"https://t.co/sVZBEZk3NY","expanded_url":"http://j.mp/2cdaHfJ","display_url":"j.mp/2cdaHfJ","indices":[108,131]}]},"source":"<a href=\"https://buffer.com\" rel=\"nofollow\">Buffer</a>","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":18064767,"id_str":"18064767","name":"meedan","screen_name":"meedan","location":"HQ: SF and Global","description":"Building software and initiatives to strengthen journalism, digital literacy, and accessibility of information. Also: @check https://t.co/NCIxwEB5k5","url":"https://t.co/dmGIPVWWiA","entities":{"url":{"urls":[{"url":"https://t.co/dmGIPVWWiA","expanded_url":"http://meedan.com","display_url":"meedan.com","indices":[0,23]}]},"description":{"urls":[{"url":"https://t.co/NCIxwEB5k5","expanded_url":"http://learnaboutcovid19.org","display_url":"learnaboutcovid19.org","indices":[125,148]}]}},"protected":false,"followers_count":10936,"friends_count":2239,"listed_count":660,"created_at":"Fri Dec 12 00:14:45 +0000 2008","favourites_count":1013,"utc_offset":null,"time_zone":null,"geo_enabled":true,"verified":true,"statuses_count":15784,"lang":null,"contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"000000","profile_background_image_url":"http://abs.twimg.com/images/themes/theme15/bg.png","profile_background_image_url_https":"https://abs.twimg.com/images/themes/theme15/bg.png","profile_background_tile":false,"profile_image_url":"http://pbs.twimg.com/profile_images/875455750557937664/HAjXGzZ2_normal.jpg","profile_image_url_https":"https://pbs.twimg.com/profile_images/875455750557937664/HAjXGzZ2_normal.jpg","profile_banner_url":"https://pbs.twimg.com/profile_banners/18064767/1441153992","profile_link_color":"4A913C","profile_sidebar_border_color":"000000","profile_sidebar_fill_color":"000000","profile_text_color":"000000","profile_use_background_image":false,"has_extended_profile":false,"default_profile":false,"default_profile_image":false,"following":false,"follow_request_sent":false,"notifications":false,"translator_type":"regular"},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":11,"favorite_count":7,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"en"}},"archives":{},"metrics":{"facebook":{"reaction_count":0,"comment_count":0,"share_count":0,"comment_plugin_count":0}},"url":"https://twitter.com/meedan/status/773947372527288320/","provider":"twitter","type":"item","parsed_at":"2020-08-08 14:19:03 +0000","favicon":"https://www.google.com/s2/favicons?domain_url=twitter.com/meedan/status/773947372527288320/","oembed":{"type":"rich","version":"1.0","title":"Thrilled to announce our participation in #Electionland w/@propublica @firstdraftnews and introduce @Check https://t.co/sVZBEZk3NY","author_name":"@meedan","author_url":"","provider_name":"twitter","provider_url":"http://twitter.com","thumbnail_url":null,"html":"<iframe src=\"https://twitter.com/meedan/status/773947372527288320/\" width=\"800\" height=\"200\" scrolling=\"no\" border=\"0\" seamless>Not supported</iframe>","width":800,"height":200},"webhook_called":1,"embed_tag":"<script src=\"https://qa-pender.checkmedia.org/api/medias.js?url=https://twitter.com/meedan/status/773947372527288320\" type=\"text/javascript\"></script>"}
+{
+  "type": "media",
+  "data": {
+    "published_at": "2022-06-23T11:08:21Z",
+    "username": "Meedan",
+    "title": "Co·Insights: Fostering community collaboration to combat misinformation",
+    "description": "Co·Insights is a NSF-proposal to create a community-led web platform with data and machine learning to support community, fact-checking, and academic organizations to identify, preempt, and respond to misinformation in minioritized communities. Learn more at https://meedan.com/project/co-insights",
+    "picture": "http://localhost:9000/check-dev/medias/f5fb82b66355ae91e82022df1a705994/picture.jpg",
+    "author_url": "https://www.youtube.com/channel/UCKyn6nCR9fXFhDL-WeeyOzQ",
+    "author_picture": "http://localhost:9000/check-dev/medias/f5fb82b66355ae91e82022df1a705994/author_picture.jpg",
+    "author_name": "Meedan",
+    "screenshot": "",
+    "external_id": "bEAdvXRJ9mU",
+    "html": "\\u003ciframe width='480' height='270' src='//www.youtube.com/embed/bEAdvXRJ9mU' frameborder='0' allow='accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture' allowfullscreen\\u003e\\u003c/iframe\\u003e",
+    "metrics": {},
+    "archives": {},
+    "raw": {
+      "json+ld": [
+        {
+          "@context": "http://schema.org",
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "item": {
+                "@id": "http://www.youtube.com/@meedan1365",
+                "name": "Meedan"
+              }
+            }
+          ]
+        }
+      ],
+      "metatags": [
+        {
+          "http-equiv": "X-UA-Compatible",
+          "content": "IE=edge"
+        },
+        {
+          "http-equiv": "origin-trial",
+          "content": "ApvK67ociHgr2egd6c2ZjrfPuRs8BHcvSggogIOPQNH7GJ3cVlyJ1NOq/COCdj0+zxskqHt9HgLLETc8qqD+vwsAAABteyJvcmlnaW4iOiJodHRwczovL3lvdXR1YmUuY29tOjQ0MyIsImZlYXR1cmUiOiJQcml2YWN5U2FuZGJveEFkc0FQSXMiLCJleHBpcnkiOjE2OTUxNjc5OTksImlzU3ViZG9tYWluIjp0cnVlfQ=="
+        },
+        {
+          "name": "theme-color",
+          "content": "rgba(255, 255, 255, 0.98)"
+        },
+        {
+          "name": "title",
+          "content": "Co·Insights: Fostering community collaboration to combat misinformation"
+        },
+        {
+          "name": "description",
+          "content": "Co·Insights is a NSF-proposal to create a community-led web platform with data and machine learning to support community, fact-checking, and academic organiz..."
+        },
+        {
+          "name": "keywords",
+          "content": "video, sharing, camera phone, video phone, free, upload"
+        },
+        {
+          "property": "og:site_name",
+          "content": "YouTube"
+        },
+        {
+          "property": "og:url",
+          "content": "https://www.youtube.com/watch?v=bEAdvXRJ9mU"
+        },
+        {
+          "property": "og:title",
+          "content": "Co·Insights: Fostering community collaboration to combat misinformation"
+        },
+        {
+          "property": "og:image",
+          "content": "https://i.ytimg.com/vi/bEAdvXRJ9mU/maxresdefault.jpg"
+        },
+        {
+          "property": "og:image:width",
+          "content": "1280"
+        },
+        {
+          "property": "og:image:height",
+          "content": "720"
+        },
+        {
+          "property": "og:description",
+          "content": "Co·Insights is a NSF-proposal to create a community-led web platform with data and machine learning to support community, fact-checking, and academic organiz..."
+        },
+        {
+          "property": "al:ios:app_store_id",
+          "content": "544007664"
+        },
+        {
+          "property": "al:ios:app_name",
+          "content": "YouTube"
+        },
+        {
+          "property": "al:ios:url",
+          "content": "vnd.youtube://www.youtube.com/watch?feature=shared\\u0026v=bEAdvXRJ9mU\\u0026feature=applinks"
+        },
+        {
+          "property": "al:android:url",
+          "content": "vnd.youtube://www.youtube.com/watch?feature=shared\\u0026v=bEAdvXRJ9mU\\u0026feature=applinks"
+        },
+        {
+          "property": "al:web:url",
+          "content": "http://www.youtube.com/watch?feature=shared\\u0026v=bEAdvXRJ9mU\\u0026feature=applinks"
+        },
+        {
+          "property": "og:type",
+          "content": "video.other"
+        },
+        {
+          "property": "og:video:url",
+          "content": "https://www.youtube.com/embed/bEAdvXRJ9mU"
+        },
+        {
+          "property": "og:video:secure_url",
+          "content": "https://www.youtube.com/embed/bEAdvXRJ9mU"
+        },
+        {
+          "property": "og:video:type",
+          "content": "text/html"
+        },
+        {
+          "property": "og:video:width",
+          "content": "1280"
+        },
+        {
+          "property": "og:video:height",
+          "content": "720"
+        },
+        {
+          "property": "al:android:app_name",
+          "content": "YouTube"
+        },
+        {
+          "property": "al:android:package",
+          "content": "com.google.android.youtube"
+        },
+        {
+          "property": "fb:app_id",
+          "content": "87741124305"
+        },
+        {
+          "name": "twitter:card",
+          "content": "player"
+        },
+        {
+          "name": "twitter:site",
+          "content": "@youtube"
+        },
+        {
+          "name": "twitter:url",
+          "content": "https://www.youtube.com/watch?v=bEAdvXRJ9mU"
+        },
+        {
+          "name": "twitter:title",
+          "content": "Co·Insights: Fostering community collaboration to combat misinformation"
+        },
+        {
+          "name": "twitter:description",
+          "content": "Co·Insights is a NSF-proposal to create a community-led web platform with data and machine learning to support community, fact-checking, and academic organiz..."
+        },
+        {
+          "name": "twitter:image",
+          "content": "https://i.ytimg.com/vi/bEAdvXRJ9mU/maxresdefault.jpg"
+        },
+        {
+          "name": "twitter:app:name:iphone",
+          "content": "YouTube"
+        },
+        {
+          "name": "twitter:app:id:iphone",
+          "content": "544007664"
+        },
+        {
+          "name": "twitter:app:name:ipad",
+          "content": "YouTube"
+        },
+        {
+          "name": "twitter:app:id:ipad",
+          "content": "544007664"
+        },
+        {
+          "name": "twitter:app:url:iphone",
+          "content": "vnd.youtube://www.youtube.com/watch?feature=shared\\u0026v=bEAdvXRJ9mU\\u0026feature=applinks"
+        },
+        {
+          "name": "twitter:app:url:ipad",
+          "content": "vnd.youtube://www.youtube.com/watch?feature=shared\\u0026v=bEAdvXRJ9mU\\u0026feature=applinks"
+        },
+        {
+          "name": "twitter:app:name:googleplay",
+          "content": "YouTube"
+        },
+        {
+          "name": "twitter:app:id:googleplay",
+          "content": "com.google.android.youtube"
+        },
+        {
+          "name": "twitter:app:url:googleplay",
+          "content": "https://www.youtube.com/watch?v=bEAdvXRJ9mU"
+        },
+        {
+          "name": "twitter:player",
+          "content": "https://www.youtube.com/embed/bEAdvXRJ9mU"
+        },
+        {
+          "name": "twitter:player:width",
+          "content": "1280"
+        },
+        {
+          "name": "twitter:player:height",
+          "content": "720"
+        },
+        {
+          "itemprop": "name",
+          "content": "Co·Insights: Fostering community collaboration to combat misinformation"
+        },
+        {
+          "itemprop": "description",
+          "content": "Co·Insights is a NSF-proposal to create a community-led web platform with data and machine learning to support community, fact-checking, and academic organiz..."
+        },
+        {
+          "itemprop": "requiresSubscription",
+          "content": "False"
+        },
+        {
+          "itemprop": "identifier",
+          "content": "bEAdvXRJ9mU"
+        },
+        {
+          "itemprop": "duration",
+          "content": "PT3M34S"
+        },
+        {
+          "itemprop": "width",
+          "content": "1280"
+        },
+        {
+          "itemprop": "height",
+          "content": "720"
+        },
+        {
+          "itemprop": "playerType",
+          "content": "HTML5 Flash"
+        },
+        {
+          "itemprop": "width",
+          "content": "1280"
+        },
+        {
+          "itemprop": "height",
+          "content": "720"
+        },
+        {
+          "itemprop": "isFamilyFriendly",
+          "content": "true"
+        },
+        {
+          "itemprop": "regionsAllowed",
+          "content": "AD,AE,AF,AG,AI,AL,AM,AO,AQ,AR,AS,AT,AU,AW,AX,AZ,BA,BB,BD,BE,BF,BG,BH,BI,BJ,BL,BM,BN,BO,BQ,BR,BS,BT,BV,BW,BY,BZ,CA,CC,CD,CF,CG,CH,CI,CK,CL,CM,CN,CO,CR,CU,CV,CW,CX,CY,CZ,DE,DJ,DK,DM,DO,DZ,EC,EE,EG,EH,ER,ES,ET,FI,FJ,FK,FM,FO,FR,GA,GB,GD,GE,GF,GG,GH,GI,GL,GM,GN,GP,GQ,GR,GS,GT,GU,GW,GY,HK,HM,HN,HR,HT,HU,ID,IE,IL,IM,IN,IO,IQ,IR,IS,IT,JE,JM,JO,JP,KE,KG,KH,KI,KM,KN,KP,KR,KW,KY,KZ,LA,LB,LC,LI,LK,LR,LS,LT,LU,LV,LY,MA,MC,MD,ME,MF,MG,MH,MK,ML,MM,MN,MO,MP,MQ,MR,MS,MT,MU,MV,MW,MX,MY,MZ,NA,NC,NE,NF,NG,NI,NL,NO,NP,NR,NU,NZ,OM,PA,PE,PF,PG,PH,PK,PL,PM,PN,PR,PS,PT,PW,PY,QA,RE,RO,RS,RU,RW,SA,SB,SC,SD,SE,SG,SH,SI,SJ,SK,SL,SM,SN,SO,SR,SS,ST,SV,SX,SY,SZ,TC,TD,TF,TG,TH,TJ,TK,TL,TM,TN,TO,TR,TT,TV,TW,TZ,UA,UG,UM,US,UY,UZ,VA,VC,VE,VG,VI,VN,VU,WF,WS,YE,YT,ZA,ZM,ZW"
+        },
+        {
+          "itemprop": "interactionCount",
+          "content": "134"
+        },
+        {
+          "itemprop": "datePublished",
+          "content": "2022-06-23"
+        },
+        {
+          "itemprop": "uploadDate",
+          "content": "2022-06-23"
+        },
+        {
+          "itemprop": "genre",
+          "content": "Nonprofits \\u0026 Activism"
+        }
+      ],
+      "api": {
+        "description": "Co·Insights is a NSF-proposal to create a community-led web platform with data and machine learning to support community, fact-checking, and academic organizations to identify, preempt, and respond to misinformation in minioritized communities. Learn more at https://meedan.com/project/co-insights",
+        "title": "Co·Insights: Fostering community collaboration to combat misinformation",
+        "published_at": "2022-06-23T11:08:21Z",
+        "thumbnails": {
+          "default": {
+            "url": "https://i.ytimg.com/vi/bEAdvXRJ9mU/default.jpg",
+            "width": 120,
+            "height": 90
+          },
+          "medium": {
+            "url": "https://i.ytimg.com/vi/bEAdvXRJ9mU/mqdefault.jpg",
+            "width": 320,
+            "height": 180
+          },
+          "high": {
+            "url": "https://i.ytimg.com/vi/bEAdvXRJ9mU/hqdefault.jpg",
+            "width": 480,
+            "height": 360
+          },
+          "standard": {
+            "url": "https://i.ytimg.com/vi/bEAdvXRJ9mU/sddefault.jpg",
+            "width": 640,
+            "height": 480
+          },
+          "maxres": {
+            "url": "https://i.ytimg.com/vi/bEAdvXRJ9mU/maxresdefault.jpg",
+            "width": 1280,
+            "height": 720
+          }
+        },
+        "channel_title": "Meedan",
+        "channel_id": "UCKyn6nCR9fXFhDL-WeeyOzQ",
+        "id": "bEAdvXRJ9mU"
+      },
+      "oembed": {
+        "title": "Co·Insights: Fostering community collaboration to combat misinformation",
+        "author_name": "Meedan",
+        "author_url": "https://www.youtube.com/@meedan1365",
+        "type": "video",
+        "height": 113,
+        "width": 200,
+        "version": "1.0",
+        "provider_name": "YouTube",
+        "provider_url": "https://www.youtube.com/",
+        "thumbnail_height": 360,
+        "thumbnail_width": 480,
+        "thumbnail_url": "https://i.ytimg.com/vi/bEAdvXRJ9mU/hqdefault.jpg",
+        "html": "\\u003ciframe width=\"200\" height=\"113\" src=\"https://www.youtube.com/embed/bEAdvXRJ9mU?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen title=\"Co·Insights: Fostering community collaboration to combat misinformation\"\\u003e\\u003c/iframe\\u003e"
+      }
+    },
+    "url": "https://www.youtube.com/watch?v=bEAdvXRJ9mU",
+    "provider": "youtube",
+    "type": "item",
+    "parsed_at": "2023-08-24 12:39:59 +0000",
+    "favicon": "https://www.google.com/s2/favicons?domain_url=www.youtube.com/watch?v=bEAdvXRJ9mU",
+    "oembed": {
+      "title": "Co·Insights: Fostering community collaboration to combat misinformation",
+      "author_name": "Meedan",
+      "author_url": "https://www.youtube.com/@meedan1365",
+      "type": "video",
+      "height": 113,
+      "width": 200,
+      "version": "1.0",
+      "provider_name": "YouTube",
+      "provider_url": "https://www.youtube.com/",
+      "thumbnail_height": 360,
+      "thumbnail_width": 480,
+      "thumbnail_url": "https://i.ytimg.com/vi/bEAdvXRJ9mU/hqdefault.jpg",
+      "html": "\\u003ciframe width=\"200\" height=\"113\" src=\"https://www.youtube.com/embed/bEAdvXRJ9mU?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen title=\"Co·Insights: Fostering community collaboration to combat misinformation\"\\u003e\\u003c/iframe\\u003e"
+    },
+    "embed_tag": "\\u003cscript src=\"http://localhost:3200/api/medias.js?refresh=1\\u0026url=https://youtu.be/bEAdvXRJ9mU?feature=shared\" type=\"text/javascript\"\\u003e\\u003c/script\\u003e"
+  }
+}

--- a/spec/lib/pender_client_test.rb
+++ b/spec/lib/pender_client_test.rb
@@ -13,7 +13,7 @@
 #
 describe PenderClient do
   before do
-    stub_request(:get, "#{Settings.get_safe_url("pender_host_url")}api/medias.json?url=https://twitter.com/meedan/status/773947372527288320/").
+    stub_request(:get, "#{Settings.get_safe_url("pender_host_url")}api/medias.json?url=https://www.youtube.com/watch?v=bEAdvXRJ9mU").
       with(
         headers: {
           'Accept'=>'*/*',
@@ -37,13 +37,13 @@ describe PenderClient do
     end
 
     it 'expects a pender response' do
-      expect(PenderClient.get_enrichment_for_url("https://twitter.com/meedan/status/773947372527288320/")).to(eq(JSON.parse(File.read("spec/fixtures/pender_response.json"))))
+      expect(PenderClient.get_enrichment_for_url("https://www.youtube.com/watch?v=bEAdvXRJ9mU")).to(eq(JSON.parse(File.read("spec/fixtures/pender_response.json"))))
     end
 
     it 'degrades gracefully when Alegre errors out' do
       RestClient::ServiceUnavailable.any_instance.stub(:http_code).and_return(500)
       RestClient::Request.stub(:execute).and_raise(RestClient::ServiceUnavailable.new)
-      expect(PenderClient.get_enrichment_for_url("https://twitter.com/meedan/status/773947372527288320/")).to(eq({}))
+      expect(PenderClient.get_enrichment_for_url("https://www.youtube.com/watch?v=bEAdvXRJ9mU")).to(eq({}))
     end
   end
 end


### PR DESCRIPTION
We are getting a few 429 ('too many requests') on sentry caused by fetch. Those items are not being created, they should be created with the default value. So, at least for now, we are removing twitter from `allowed_hostnames`.

As part of this I had to update some tests that were using a twitter url (changed it to a youtube one), and updated the fixture (`pender_response.json`) to be the one from youtube.

Relates to this [PR](https://github.com/meedan/pender/pull/380)