### PR TITLE
4383 – Deprecate multiple parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,23 @@ Once in place, all that's needed is pushing the new subclass to dev and then pro
 
 Sometimes, parsing is more complicated - if the pagination mechanism is `JSON` based (i.e. some asynchronous event like a "load more" at the bottom of a page), you can specify that and have pages render as JSON objects rather than Nokogiri-parsed HTML by adding a `@fact_list_page_parser = 'json'` into the class initialization. If you need to slow down the parser, add a `@per_article_sleep_time = 3` and a `@run_in_parallel = false` to the initialization to specify how long it should pause between article parses, and whether or not it should run multiple at the same time. Rarely, pagination routines are too complex for `PaginatedReviewClaims`, and need to be explicitly written. Examples of that sort of situation are hard to generalize, but you can see how that's been dealt with in `GoogleFactCheck`, `BoomLive`, `DataCommons`, `Mafindo`, and a few others.
 
-In other situations, light overrides of `PaginatedReviewClaims` logic is necessary as seen in `NewtralFakes`, `PesaCheck`, and `TempoCekfakta`. In rare cases, we fully stop supporting scrapers, but want to keep the code in case we have to re-enable - that's done with a `self.deprecated` method return value of `true` as seen in `Tattle`, `AajtakIndiaToday`, and a few others.
+In other situations, light overrides of `PaginatedReviewClaims` logic is necessary as seen in `NewtralFakes`, `PesaCheck`, and `TempoCekfakta`. 
+
+## Deprecating a Parser
+
+If we fully stop supporting scrapers, we want to keep the code in case we have to re-enable - that's done with a `self.deprecated` method return value of `true` as seen in `Tattle`, `AajtakIndiaToday`, and a few others.
+
+```
+class ParserName < ClaimReviewParser
+  include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
+  (...)
+  
+end
+```
 
 ## Reimporting/Rebuilding/Debugging an existing data Source
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ If we fully stop supporting scrapers, we want to keep the code in case we have t
 
 ```
 class ParserName < ClaimReviewParser
-  include PaginatedReviewClaims
   def self.deprecated
     true
   end

--- a/lib/claim_review_parsers/comprova.rb
+++ b/lib/claim_review_parsers/comprova.rb
@@ -3,6 +3,10 @@
 # Parser for https://projetocomprova.com.br/
 class Comprova < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def hostname
     'https://projetocomprova.com.br'
   end

--- a/lib/claim_review_parsers/estadao.rb
+++ b/lib/claim_review_parsers/estadao.rb
@@ -3,6 +3,10 @@
 # Parser for https://www.estadao.com.br
 class Estadao < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'json'

--- a/lib/claim_review_parsers/newtral_fact_check.rb
+++ b/lib/claim_review_parsers/newtral_fact_check.rb
@@ -4,6 +4,11 @@
 require_relative('newtral_fakes')
 class NewtralFactCheck < NewtralFakes
   include PaginatedReviewClaims
+  include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def relevant_sitemap_subpath
     "www.newtral.es/factcheck"
   end

--- a/lib/claim_review_parsers/newtral_fact_check.rb
+++ b/lib/claim_review_parsers/newtral_fact_check.rb
@@ -4,7 +4,6 @@
 require_relative('newtral_fakes')
 class NewtralFactCheck < NewtralFakes
   include PaginatedReviewClaims
-  include PaginatedReviewClaims
   def self.deprecated
     true
   end

--- a/lib/claim_review_parsers/newtral_fakes.rb
+++ b/lib/claim_review_parsers/newtral_fakes.rb
@@ -7,7 +7,6 @@
 # Parser for https://www.newtral.es
 class NewtralFakes < ClaimReviewParser
   include PaginatedReviewClaims
-  include PaginatedReviewClaims
   def self.deprecated
     true
   end

--- a/lib/claim_review_parsers/newtral_fakes.rb
+++ b/lib/claim_review_parsers/newtral_fakes.rb
@@ -7,6 +7,11 @@
 # Parser for https://www.newtral.es
 class NewtralFakes < ClaimReviewParser
   include PaginatedReviewClaims
+  include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @per_article_sleep_time = 3

--- a/lib/claim_review_parsers/pesa_check.rb
+++ b/lib/claim_review_parsers/pesa_check.rb
@@ -3,6 +3,9 @@
 # Parser for https://medium.com/feed/@pesacheck
 class PesaCheck < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
 
   def get_articles
     JSON.parse(get_url("https://api.rss2json.com/v1/api.json?rss_url=https://pesacheck.org/feed"))["items"]

--- a/lib/claim_review_parsers/tempo_cekfakta.rb
+++ b/lib/claim_review_parsers/tempo_cekfakta.rb
@@ -1,5 +1,9 @@
 class TempoCekfakta < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @user_agent = "Meedan Data Crawler"

--- a/lib/claim_review_parsers/thip.rb
+++ b/lib/claim_review_parsers/thip.rb
@@ -4,6 +4,10 @@
 class Thip < ClaimReviewParser
   attr_accessor :raw_response
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims = false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'json'

--- a/lib/claim_review_parsers/twenty_minutes.rb
+++ b/lib/claim_review_parsers/twenty_minutes.rb
@@ -4,6 +4,10 @@
 class TwentyMinutes < ClaimReviewParser
   attr_accessor :raw_response
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'html_first_then_json'


### PR DESCRIPTION
## Description

1. We are deprecating multiple parsers. They are either using the Zapier RSS/Check integration or the API.
    - 20 minutes - RSS
    - Estadao - RSS
    - THIP - RSS
    - PesaCheck - API
    - Comprova - API
    - Newtral - API (both `newtral_fact_check` and `newtral_fakes`)
    - CekFakta - API (`tempo_cekfakta` parser)
    - Tempo - API (`tempo_cekfakta` parser)
    
2. Updating the README, so the _how to deprecate_ is more visible.

References: 4383, 4349, 4347, 4300

