### PR TITLE
4403 – Deprecate Uol parsers

### DIFF
--- a/lib/claim_review_parsers/uol_comprova.rb
+++ b/lib/claim_review_parsers/uol_comprova.rb
@@ -4,6 +4,10 @@
 class UOLComprova < ClaimReviewParser
   include PaginatedReviewClaims
   attr_accessor :next_page
+  def self.deprecated
+    true
+  end
+
   def self.interevent_time
     60*5
   end

--- a/lib/claim_review_parsers/uol_confere.rb
+++ b/lib/claim_review_parsers/uol_confere.rb
@@ -3,6 +3,10 @@
 # Parser for https://noticias.uol.com.br
 class UOLConfere < UOLComprova
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def self.interevent_time
     60*5
   end

--- a/lib/claim_review_parsers/uol_eleicoes_ultima.rb
+++ b/lib/claim_review_parsers/uol_eleicoes_ultima.rb
@@ -3,6 +3,10 @@
 # Parser for https://noticias.uol.com.br
 class UOLEleicoesUltima < UOLComprova
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def fact_list_path(next_page=nil)
     "/eleicoes/ultimas/?next=#{next_page}"
   end


### PR DESCRIPTION
## Description

Uol is now using the API, so we can deprecate their parser.

References: 4403

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

