### PR TITLE
CV2-5098 add a stopgap job timeout

### DIFF
--- a/tasks/run_claim_review_parser.rb
+++ b/tasks/run_claim_review_parser.rb
@@ -1,13 +1,29 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 class RunClaimReviewParser
   include Sidekiq::Worker
+
+  MAX_RUNTIME = 60 * 60 # 1 hour in seconds
+
   def perform(service, cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications=true)
     cursor_back_to_date = Time.parse(cursor_back_to_date) unless cursor_back_to_date.nil?
     ClaimReviewParser.record_service_heartbeat(service)
-    
-    ClaimReviewParser.run(service, cursor_back_to_date, overwrite_existing_claims, send_notifications)
-    RunClaimReviewParser.perform_in(ClaimReviewParser.parsers[service].interevent_time, service) if !ClaimReviewParser.parsers[service].deprecated
+
+    begin
+      Timeout.timeout(MAX_RUNTIME) do
+        ClaimReviewParser.run(service, cursor_back_to_date, overwrite_existing_claims, send_notifications)
+      end
+    rescue Timeout::Error
+      # Handle timeout - log the error, send notification, requeue, etc.
+      handle_timeout(service)
+    ensure
+      # Requeue the job if the parser is not deprecated
+      if !ClaimReviewParser.parsers[service].deprecated
+        RunClaimReviewParser.perform_in(ClaimReviewParser.parsers[service].interevent_time, service)
+      end
+    end
   end
 
   def self.requeue(service)
@@ -16,5 +32,15 @@ class RunClaimReviewParser
       return true
     end
     false
+  end
+
+  private
+
+  def handle_timeout(service)
+    # Log the timeout occurrence
+    logger.error("Timeout reached for #{service} in RunClaimReviewParser")
+    # Additional actions like sending notifications can be added here
+    # Optionally requeue the job immediately
+    RunClaimReviewParser.requeue(service)
   end
 end


### PR DESCRIPTION
## Description

Some jobs are sitting running forever - not ideal - so let's just add a nuclear option.

References: CV2-5098

## How has this been tested?

Not yet tested will review in qa

## Things to pay attention to during code review

None in particular 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

