### PR TITLE
4981 – Deprecate multiple parsers

### DIFF
--- a/lib/claim_review_parsers/aajtak_hindi.rb
+++ b/lib/claim_review_parsers/aajtak_hindi.rb
@@ -3,6 +3,10 @@
 # Parser for https://www.aajtak.in
 class AajtakHindi < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'json'

--- a/lib/claim_review_parsers/africa_check.rb
+++ b/lib/claim_review_parsers/africa_check.rb
@@ -3,6 +3,10 @@
 # Parser for https://africacheck.org
 class AfricaCheck < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def hostname
     'https://africacheck.org'
   end

--- a/lib/claim_review_parsers/alt_news_in.rb
+++ b/lib/claim_review_parsers/alt_news_in.rb
@@ -3,6 +3,10 @@
 # Parser for https://www.altnews.in
 class AltNewsIn < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def hostname
     'https://www.altnews.in/'
   end

--- a/lib/claim_review_parsers/fact_check_cite.rb
+++ b/lib/claim_review_parsers/fact_check_cite.rb
@@ -2,6 +2,10 @@
 
 class FactCheckCite < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'json'

--- a/lib/claim_review_parsers/globo.rb
+++ b/lib/claim_review_parsers/globo.rb
@@ -4,6 +4,10 @@
 class Globo < ClaimReviewParser
   attr_accessor :raw_response
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'json'

--- a/lib/claim_review_parsers/la_silla_vacia.rb
+++ b/lib/claim_review_parsers/la_silla_vacia.rb
@@ -3,6 +3,10 @@
 # Parser for https://www.lasillavacia.com/la-silla-vacia/detector-de-mentiras/
 class LaSillaVacia < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'html_body_encased_html'

--- a/lib/claim_review_parsers/lupa.rb
+++ b/lib/claim_review_parsers/lupa.rb
@@ -3,6 +3,10 @@
 # Parser for https://piaui.folha.uol.com.br
 class Lupa < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def hostname
     'https://piaui.folha.uol.com.br'
   end

--- a/lib/claim_review_parsers/piyaoba.rb
+++ b/lib/claim_review_parsers/piyaoba.rb
@@ -3,6 +3,10 @@
 # Parser for https://www.piyaoba.org
 class Piyaoba < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def hostname
     'https://www.piyaoba.org'
   end

--- a/lib/claim_review_parsers/vera_files.rb
+++ b/lib/claim_review_parsers/vera_files.rb
@@ -3,6 +3,10 @@
 # Parser for https://verafiles.org/specials/fact-check
 class VeraFiles < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @proxy = Settings.get("static_ip_proxy_url")

--- a/lib/claim_review_parsers/vera_files_filipino.rb
+++ b/lib/claim_review_parsers/vera_files_filipino.rb
@@ -3,6 +3,10 @@
 # Parser for https://verafiles.org/specials/fact-check-filipino
 class VeraFilesFilipino < VeraFiles
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def fact_list_path(page = 1)
     "/specials/fact-check-filipino?ccm_paging_p=#{page}"
   end

--- a/spec/tasks/check_for_stale_parsers_test.rb
+++ b/spec/tasks/check_for_stale_parsers_test.rb
@@ -3,9 +3,9 @@
 describe CheckForStaleParsers do
   describe 'instance' do
     it 'responds to perform' do
-      API.stub(:services).and_return({services: [{:service=>"lupa", :count=>6889, :earliest=>"2018-01-16", :latest=>(Time.now-60*60*24*10).strftime("%Y-%m-%d")}, {:service=>"other_parser", :count=>6889, :earliest=>"2018-01-16", :latest=>(Time.now-60*60*24*1).strftime("%Y-%m-%d")}]})
+      API.stub(:services).and_return({services: [{:service=>"reuters_brazil", :count=>6889, :earliest=>"2018-01-16", :latest=>(Time.now-60*60*24*10).strftime("%Y-%m-%d")}, {:service=>"other_parser", :count=>6889, :earliest=>"2018-01-16", :latest=>(Time.now-60*60*24*1).strftime("%Y-%m-%d")}]})
       response = described_class.new.perform
-      expect(response).to(eq(["lupa"]))
+      expect(response).to(eq(["reuters_brazil"]))
     end
   end
 end


### PR DESCRIPTION
## Description

#### Deprecates:
CV2-5046 – We are now importing via the Zapier/Check integration:
1. Piyaoba

CV2-4981 – We confirmed the parsers below can be deprecated:
1. aajtak_hindi – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881")
2. africa_check – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881")
4. agência lupa – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50850 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50850")
5. alt_news_in – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881")
6. fact_check_cite – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50850 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50850")
7. globo – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881")
8. la_silla_vacia – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=50881")
9. vera_files – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=51344 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=51344")
10. vera_files_filipino – [confirmation](https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=51344 "https://meedan.atlassian.net/browse/CV2-4981?focusedCommentId=51344")

References: 5046, 4981

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Updated a test that used the `lupa` parser to use `reuters_brazil`

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

