### PR TITLE
CV2-5098 make super sure we're not contributing to runaway tasks

### DIFF
--- a/spec/tasks/run_claim_review_parser_test.rb
+++ b/spec/tasks/run_claim_review_parser_test.rb
@@ -1,25 +1,133 @@
 # frozen_string_literal: true
 
-describe RunClaimReviewParser do
+require 'rspec'
+
+# Assuming RunClaimReviewParser and related classes are already defined as provided
+
+RSpec.describe RunClaimReviewParser do
   describe 'instance' do
     it 'walks through perform task' do
-      ClaimReviewParser.stub(:run).with('foo', nil, false, true).and_return(nil)
-      ClaimReviewParser.stub(:parsers).and_return({"foo" => ClaimReviewParser})
-      RunClaimReviewParser.stub(:perform_in).with(60 * 60, 'foo').and_return(nil)
+      allow(ClaimReviewParser).to receive(:run).with('foo', nil, false, true).and_return(nil)
+      allow(ClaimReviewParser).to receive(:parsers).and_return({
+        "foo" => double(deprecated: false, interevent_time: 60 * 60)
+      })
+      allow(RunClaimReviewParser).to receive(:perform_in).with(60 * 60, 'foo').and_return(nil)
       expect(RunClaimReviewParser.new.perform('foo')).to(eq(nil))
     end
   end
   
   describe 'class' do
-    ClaimReviewParser.enabled_subclasses.map(&:service).each do |service|
-      it 'requeues when no task is present' do
-        $REDIS_CLIENT.del(ClaimReview.service_heartbeat_key(service))
-        expect(described_class.requeue(service)).to(eq(true))
+    describe '.requeue' do
+      let(:service) { 'foo' }
+
+      context 'when heartbeat key for service is nil' do
+        it 'requeues the job and returns true' do
+          allow($REDIS_CLIENT).to receive(:get)
+            .with(ClaimReview.service_heartbeat_key(service))
+            .and_return(nil)
+          expect(RunClaimReviewParser).to receive(:perform_async).with(service)
+          expect(described_class.requeue(service)).to(eq(true))
+        end
       end
 
-      it 'does not requeue when task is present' do
-        $REDIS_CLIENT.setex(ClaimReview.service_heartbeat_key(service), 60, "test")
-        expect(described_class.requeue(service)).to(eq(false))
+      context 'when heartbeat key for service is present' do
+        it 'does not requeue the job and returns false' do
+          allow($REDIS_CLIENT).to receive(:get)
+            .with(ClaimReview.service_heartbeat_key(service))
+            .and_return("test")
+          expect(RunClaimReviewParser).not_to receive(:perform_async)
+          expect(described_class.requeue(service)).to(eq(false))
+        end
+      end
+    end
+
+    describe '.not_enqueued_anywhere_else' do
+      let(:service) { 'foo' }
+
+      before do
+        # No need to clear Sidekiq sets since we're mocking them
+      end
+
+      context 'when no job with the service is enqueued' do
+        it 'returns true' do
+          # Mock RetrySet, ScheduledSet, and Queue to have no matching jobs
+          retry_set = instance_double(Sidekiq::RetrySet)
+          scheduled_set = instance_double(Sidekiq::ScheduledSet)
+          queue = instance_double(Sidekiq::Queue)
+
+          allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+          allow(Sidekiq::ScheduledSet).to receive(:new).and_return(scheduled_set)
+          allow(Sidekiq::Queue).to receive(:new).and_return(queue)
+
+          allow(retry_set).to receive(:each).and_return([])
+          allow(scheduled_set).to receive(:each).and_return([])
+          allow(queue).to receive(:each).and_return([])
+
+          expect(described_class.not_enqueued_anywhere_else(service)).to(eq(true))
+        end
+      end
+
+      context 'when a job with the service is in the RetrySet' do
+        it 'returns false' do
+          # Mock a matching job in RetrySet
+          matching_job = double('Job', item: { "args" => [service.to_s] })
+          retry_set = instance_double(Sidekiq::RetrySet)
+
+          allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+          allow(retry_set).to receive(:each).and_yield(matching_job)
+
+          # Ensure ScheduledSet and Queue do not yield any jobs
+          scheduled_set = instance_double(Sidekiq::ScheduledSet)
+          queue = instance_double(Sidekiq::Queue)
+          allow(Sidekiq::ScheduledSet).to receive(:new).and_return(scheduled_set)
+          allow(Sidekiq::Queue).to receive(:new).and_return(queue)
+          allow(scheduled_set).to receive(:each).and_return([])
+          allow(queue).to receive(:each).and_return([])
+
+          expect(described_class.not_enqueued_anywhere_else(service)).to(eq(false))
+        end
+      end
+
+      context 'when a job with the service is in the ScheduledSet' do
+        it 'returns false' do
+          # Mock a matching job in ScheduledSet
+          matching_job = double('Job', item: { "args" => [service.to_s] })
+          scheduled_set = instance_double(Sidekiq::ScheduledSet)
+
+          allow(Sidekiq::ScheduledSet).to receive(:new).and_return(scheduled_set)
+          allow(scheduled_set).to receive(:each).and_yield(matching_job)
+
+          # Ensure RetrySet and Queue do not yield any jobs
+          retry_set = instance_double(Sidekiq::RetrySet)
+          queue = instance_double(Sidekiq::Queue)
+          allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+          allow(Sidekiq::Queue).to receive(:new).and_return(queue)
+          allow(retry_set).to receive(:each).and_return([])
+          allow(queue).to receive(:each).and_return([])
+
+          expect(described_class.not_enqueued_anywhere_else(service)).to(eq(false))
+        end
+      end
+
+      context 'when a job with the service is in the Queue' do
+        it 'returns false' do
+          # Mock a matching job in Queue
+          matching_job = double('Job', item: { "args" => [service.to_s] })
+          queue = instance_double(Sidekiq::Queue)
+
+          allow(Sidekiq::Queue).to receive(:new).and_return(queue)
+          allow(queue).to receive(:each).and_yield(matching_job)
+
+          # Ensure RetrySet and ScheduledSet do not yield any jobs
+          retry_set = instance_double(Sidekiq::RetrySet)
+          scheduled_set = instance_double(Sidekiq::ScheduledSet)
+          allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+          allow(Sidekiq::ScheduledSet).to receive(:new).and_return(scheduled_set)
+          allow(retry_set).to receive(:each).and_return([])
+          allow(scheduled_set).to receive(:each).and_return([])
+
+          expect(described_class.not_enqueued_anywhere_else(service)).to(eq(false))
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Sometimes we have an error state in a job, and that job begets another job, which begets another... until we have millions of jobs piled up. This is a catch all function to really, really try to prevent that under any circumstance.
References: CV2-5098

## How has this been tested?

Tested against real queues while developing, added realistic tests to ensure as well.

## Things to pay attention to during code review

Nothing in particular 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

