### PR TITLE
CV2-5098 refactor requeue and add to every worker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,15 +74,6 @@ task :safe_init_index do
 end
 
 task :requeue do
-  ClaimReviewParser.enabled_subclasses.map(&:service).each do |datasource|
-    puts "Resetting crawls for #{datasource}..."
-    result = RunClaimReviewParser.requeue(datasource)
-    if result
-      puts "Update for #{datasource} is queued."
-    else
-      puts "Update for #{datasource} failed to queue, already queued."
-    end
-    ClaimReviewParser.record_service_heartbeat(datasource)
-  end
+  ClaimReviewParser.requeue_all
 end
 task(default: [:test])

--- a/lib/claim_review_parser.rb
+++ b/lib/claim_review_parser.rb
@@ -129,4 +129,17 @@ class ClaimReviewParser
     end
     false
   end
+
+  def self.requeue_all
+    self.enabled_subclasses.map(&:service).each do |datasource|
+      puts "Resetting crawls for #{datasource}..."
+      result = RunClaimReviewParser.requeue(datasource)
+      if result
+        puts "Update for #{datasource} is queued."
+      else
+        puts "Update for #{datasource} failed to queue, already queued."
+      end
+      self.record_service_heartbeat(datasource)
+    end
+  end
 end

--- a/tasks/run_claim_review_parser.rb
+++ b/tasks/run_claim_review_parser.rb
@@ -22,6 +22,8 @@ class RunClaimReviewParser
       # Requeue the job if the parser is not deprecated
       if !ClaimReviewParser.parsers[service].deprecated && RunClaimReviewParser.not_enqueued_anywhere_else(service)
         RunClaimReviewParser.perform_in(ClaimReviewParser.parsers[service].interevent_time, service)
+        #Be neighborly and requeue any other jobs that may be behind
+        ClaimReviewParser.requeue_all
       end
     end
   end

--- a/tasks/run_claim_review_parser.rb
+++ b/tasks/run_claim_review_parser.rb
@@ -29,7 +29,7 @@ class RunClaimReviewParser
   end
 
   def self.requeue(service)
-    if $REDIS_CLIENT.get(ClaimReview.service_heartbeat_key(service)).nil?
+    if $REDIS_CLIENT.get(ClaimReview.service_heartbeat_key(service)).nil? && RunClaimReviewParser.not_enqueued_anywhere_else(service)
       RunClaimReviewParser.perform_async(service)
       return true
     end


### PR DESCRIPTION
## Description
Sometimes some of our workers get behind and we need to run our rakefile task - I'm also adding it as a final step to *any* worker so that, so long as *any* worker is online, they will force a requeue of *all other workers* if missing.
References: CV2-5098

## How has this been tested?

Not tested, small refactor to stem ongoing issues

## Things to pay attention to during code review

NA

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

