### PR TITLE
Set default cursor date to a month

### DIFF
--- a/spec/tasks/run_claim_review_parser_test.rb
+++ b/spec/tasks/run_claim_review_parser_test.rb
@@ -7,7 +7,7 @@ require 'rspec'
 RSpec.describe RunClaimReviewParser do
   describe 'instance' do
     it 'walks through perform task' do
-      allow(ClaimReviewParser).to receive(:run).with('foo', nil, false, true).and_return(nil)
+      allow(ClaimReviewParser).to receive(:run).with('foo', anything(), false, true).and_return(nil)
       allow(ClaimReviewParser).to receive(:parsers).and_return({
         "foo" => double(deprecated: false, interevent_time: 60 * 60)
       })

--- a/tasks/run_claim_review_parser.rb
+++ b/tasks/run_claim_review_parser.rb
@@ -7,7 +7,7 @@ class RunClaimReviewParser
 
   MAX_RUNTIME = 60 * 60 # 1 hour in seconds
 
-  def perform(service, cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications=true)
+  def perform(service, cursor_back_to_date = (Time.now-60*60*24*30).to_s, overwrite_existing_claims=false, send_notifications=true)
     cursor_back_to_date = Time.parse(cursor_back_to_date) unless cursor_back_to_date.nil?
     ClaimReviewParser.record_service_heartbeat(service)
 


### PR DESCRIPTION
## Description

We almost never need to go far back in history - set it to a month (they should run every 4 hours up to the most recent article, anyways, so this doesn't effect many parsers except for reuters for some reason)

References: CV2-5098

## How has this been tested?

Tested on live machines while debugging outstanding issues

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

None in particular

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

