### PR TITLE
CV2-5098 tweak requeue logic

### DIFF
--- a/spec/tasks/run_claim_review_parser_test.rb
+++ b/spec/tasks/run_claim_review_parser_test.rb
@@ -136,7 +136,7 @@ RSpec.describe RunClaimReviewParser do
             .with(ClaimReview.service_heartbeat_key(service))
             .and_return("test")
           # Mock a matching job in RetrySet
-          matching_job = double('Job', item: { "args" => [service.to_s] })
+          matching_job = double('RunClaimReviewParser', item: { "args" => [service.to_s] })
           retry_set = instance_double(Sidekiq::RetrySet)
 
           allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
@@ -160,7 +160,7 @@ RSpec.describe RunClaimReviewParser do
             .with(ClaimReview.service_heartbeat_key(service))
             .and_return("test")
           # Mock a matching job in ScheduledSet
-          matching_job = double('Job', item: { "args" => [service.to_s] })
+          matching_job = double('RunClaimReviewParser', item: { "args" => [service.to_s] })
           scheduled_set = instance_double(Sidekiq::ScheduledSet)
 
           allow(Sidekiq::ScheduledSet).to receive(:new).and_return(scheduled_set)
@@ -184,7 +184,7 @@ RSpec.describe RunClaimReviewParser do
             .with(ClaimReview.service_heartbeat_key(service))
             .and_return("test")
           # Mock a matching job in Queue
-          matching_job = double('Job', item: { "args" => [service.to_s] })
+          matching_job = double('RunClaimReviewParser', item: { "args" => [service.to_s] })
           queue = instance_double(Sidekiq::Queue)
 
           allow(Sidekiq::Queue).to receive(:new).and_return(queue)

--- a/spec/tasks/run_claim_review_parser_test.rb
+++ b/spec/tasks/run_claim_review_parser_test.rb
@@ -150,7 +150,7 @@ RSpec.describe RunClaimReviewParser do
           allow(scheduled_set).to receive(:each).and_return([])
           allow(queue).to receive(:each).and_return([])
 
-          expect(described_class.not_enqueued_anywhere_else(service)).to(eq(false))
+          expect(described_class.should_requeue(service)).to(eq(false))
         end
       end
 
@@ -174,7 +174,7 @@ RSpec.describe RunClaimReviewParser do
           allow(retry_set).to receive(:each).and_return([])
           allow(queue).to receive(:each).and_return([])
 
-          expect(described_class.not_enqueued_anywhere_else(service)).to(eq(false))
+          expect(described_class.should_requeue(service)).to(eq(false))
         end
       end
 
@@ -198,7 +198,7 @@ RSpec.describe RunClaimReviewParser do
           allow(retry_set).to receive(:each).and_return([])
           allow(scheduled_set).to receive(:each).and_return([])
 
-          expect(described_class.not_enqueued_anywhere_else(service)).to(eq(false))
+          expect(described_class.should_requeue(service)).to(eq(false))
         end
       end
     end

--- a/tasks/run_claim_review_parser.rb
+++ b/tasks/run_claim_review_parser.rb
@@ -27,8 +27,12 @@ class RunClaimReviewParser
     end
   end
 
+  def self.should_requeue(service)
+    $REDIS_CLIENT.get(ClaimReview.service_heartbeat_key(service)).nil? || RunClaimReviewParser.not_enqueued_anywhere_else(service)
+  end
+
   def self.requeue(service)
-    if $REDIS_CLIENT.get(ClaimReview.service_heartbeat_key(service)).nil? || RunClaimReviewParser.not_enqueued_anywhere_else(service)
+    if self.should_requeue(service)
       RunClaimReviewParser.perform_async(service)
       return true
     end


### PR DESCRIPTION
## Description

Tweaks requeue logic to accommodate current persistent failure mode of one of our parsers (job runs but has a few missed notifications left in RetryQueue, has redis stamp but otherwise missing

References: CV2-5098

## How has this been tested?

Tested on servers when resolving current stuck jobs and confirmed to have unstuck

## Things to pay attention to during code review

Nothing in particular!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

