### PR TITLE
5192 – Deprecate Fetch Parsers: Remaining inactive parsers

### DIFF
--- a/lib/claim_review_parsers/climate_fact_check.rb
+++ b/lib/claim_review_parsers/climate_fact_check.rb
@@ -4,6 +4,10 @@
 # Parser for https://climatefactchecks.org
 class ClimateFactCheck < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def hostnames
     [
       "https://climatefactchecks.org/category/fact-check/",

--- a/lib/claim_review_parsers/gesis_claims.rb
+++ b/lib/claim_review_parsers/gesis_claims.rb
@@ -3,6 +3,10 @@
 # Parser for
 class GESISClaims < ClaimReviewParser
   include GenericRawClaimParser
+  def self.deprecated
+    true
+  end
+
   def post_request_get_fact_ids(page, limit)
     RestClient::Request.execute(
       :method => :post,

--- a/lib/claim_review_parsers/tfc_taiwan.rb
+++ b/lib/claim_review_parsers/tfc_taiwan.rb
@@ -3,6 +3,10 @@
 # Parser for https://tfc-taiwan.org.tw
 class TFCTaiwan < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def hostname
     'https://tfc-taiwan.org.tw'
   end


### PR DESCRIPTION
## Description

Deprecates the following inactive parsers:
1. climate_fact_check
2. gesis_claims
3. tfc_taiwan

References: CV2-5192

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

