### PR TITLE
6221 – Deprecate tsekph

### DIFF
--- a/lib/claim_review_parsers/tsek.rb
+++ b/lib/claim_review_parsers/tsek.rb
@@ -2,6 +2,10 @@
 
 class Tsek < ClaimReviewParser
   include PaginatedReviewClaims
+  def self.deprecated
+    true
+  end
+
   def initialize(cursor_back_to_date = nil, overwrite_existing_claims=false, send_notifications = true)
     super(cursor_back_to_date, overwrite_existing_claims, send_notifications)
     @fact_list_page_parser = 'json'


### PR DESCRIPTION
## Description

Deprecate the Tsek.ph parser. We are now using another integration.

References: CV2-6221

## How has this been tested?

Ran test suite to make sure we weren't using this parser for any tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings

