### PR TITLE
Dockerfile syntax update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.7
-MAINTAINER Meedan <sysops@meedan.com>
+LABEL maintainer="Meedan <sysops@meedan.com>"
 
 RUN apt-get update -qq && apt-get install -y --no-install-recommends curl build-essential libffi-dev dumb-init
 


### PR DESCRIPTION
## Description

Dockerfile syntax update. `MAINTAINER` has been deprecated for a while, it's an easy update and will stop deprecated warnings.

References: Fetch Audit