### PR TITLE
Invoke sysops deployment with image tag for Live updates.

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - 'develop'
-      - 'master'
-      - '*deploy/*'
+    tags:
+      - 'v*'
 
 permissions:
   id-token: write
@@ -94,14 +94,14 @@ jobs:
 
     - name: Kick off Terraform QA deploy in sysops/
       id: sysops-deploy-qa
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/develop')
       run: |
         curl --fail-with-body \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
+          https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_fetch.yml/dispatches \
           -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "push"}}'
       
     - name: Kick off Terraform Live deploy in sysops/
@@ -114,7 +114,7 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
+          https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_fetch.yml/dispatches \
           -d '{"ref": "master", "inputs": {"image_tag": "'$RELEASE_TAG'", "type": "tag"}}'
 
     - name: Reset cache

--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -92,29 +92,33 @@ jobs:
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH \
           --file ./Dockerfile ./
 
-    - name: Kick off Terraform deploy in sysops/ if not live
-      id: sysops-deploy
+    - name: Kick off Terraform QA deploy in sysops/
+      id: sysops-deploy-qa
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
       run: |
-        BRANCH=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
-        if [[ "$BRANCH" != master ]]; then
-          curl \
+        curl --fail-with-body \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
-          -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "branch": "'$BRANCH'"}}'
-        fi
+          -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "push"}}'
+      
+    - name: Kick off Terraform Live deploy in sysops/
+      id: sysops-deploy-live
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        RELEASE_TAG=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
+        curl --fail-with-body \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
+          -d '{"ref": "master", "inputs": {"image_tag": "'$RELEASE_TAG'", "type": "tag"}}'
 
-    - name: Send Slack Notification
-      id: slack-notify
-      if: ${{ always() }}
-      uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        author_name: 'Github Actions'
-        icon_emoji: ':octocat:'
-        fields: repo,message,author # selectable (default: repo,message)
-      env:
-        GITHUB_TOKEN: ${{ secrets.CONFIGURATOR_TOKEN }} # optional
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+    - name: Reset cache
+      id: reset-cache
+      if: ${{ success() || failure() }}
+      run: |
+        rm -rf /tmp/.buildx-cache


### PR DESCRIPTION
## Description

This change adds support for deployment workflow invocation with an image_tag input used for Live cluster updates. This resolves an error where git_sha based deployments lacked sufficient lifecycle policy in ECR to keep services running during ongoing development and CI/CD builds.

See also: https://meedan.atlassian.net/browse/CV2-6664

## Checklist

- [X] I have performed a self-review of my own code
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [X] My changes generate no new warnings

